### PR TITLE
added namespace support

### DIFF
--- a/cmd/erase.go
+++ b/cmd/erase.go
@@ -22,6 +22,12 @@ var eraseCmd = &cobra.Command{
 			return errors.New("Missing VAULT_ADDR environment variable")
 		}
 
+		vaultNamespace := os.Getenv("VAULT_NAMESPACE")
+		if vaultNamespace != "" {
+			vaultAddr += "/"
+			vaultAddr += vaultNamespace
+		}
+
 		if err := backend.Erase(vaultAddr); err != nil {
 			return err
 		}

--- a/cmd/get.go
+++ b/cmd/get.go
@@ -23,6 +23,12 @@ var getCmd = &cobra.Command{
 			return errors.New("Missing VAULT_ADDR environment variable")
 		}
 
+		vaultNamespace := os.Getenv("VAULT_NAMESPACE")
+		if vaultNamespace != "" {
+			vaultAddr += "/"
+			vaultAddr += vaultNamespace
+		}
+
 		token, err := backend.Get(vaultAddr)
 		if err != nil {
 			return err

--- a/cmd/store.go
+++ b/cmd/store.go
@@ -25,6 +25,12 @@ var storeCmd = &cobra.Command{
 			return errors.New("Missing VAULT_ADDR environment variable")
 		}
 
+		vaultNamespace := os.Getenv("VAULT_NAMESPACE")
+		if vaultNamespace != "" {
+			vaultAddr += "/"
+			vaultAddr += vaultNamespace
+		}
+
 		stdin, err := ioutil.ReadAll(os.Stdin)
 		if err != nil {
 			return errors.Wrap(err, "Failed to read token from STDIN")


### PR DESCRIPTION
This change looks for the VAULT_NAMESPACE environment variable and changes the url used to identify the secret. Vaut enterprise users with namespaces can now use this helper and save unique tokens per namespace. 